### PR TITLE
List behaves like get for undefined keys

### DIFF
--- a/src/main/java/com/justinsb/etcd/EtcdClient.java
+++ b/src/main/java/com/justinsb/etcd/EtcdClient.java
@@ -257,7 +257,11 @@ public class EtcdClient {
 
         if (response.httpStatusCode != 200) {
             EtcdResult etcdResult = parseEtcdResult(response.json);
-            throw new EtcdClientException("Error listing keys", etcdResult);
+            if (etcdResult.errorCode == 100) {
+                return null;
+            } else {
+                throw new EtcdClientException("Error listing keys", etcdResult);
+            }
         }
 
         try {

--- a/src/test/java/com/justinsb/etcd/SmokeTest.java
+++ b/src/test/java/com/justinsb/etcd/SmokeTest.java
@@ -219,7 +219,15 @@ public class SmokeTest {
             Assert.assertEquals(true, result.dir);
         }
     }
+    
+    @Test
+    public void testListWithNonexistentKey() throws Exception {
+        String key = prefix + "/nonexistent";
 
+        List<EtcdResult> listing = this.client.listChildren(key);
+        Assert.assertNull(listing);
+    }
+    
     @Test
     public void testGetVersion() throws Exception {
         String version = this.client.getVersion();


### PR DESCRIPTION
Was hoping to make list behave like get for undefined keys.  Currently if you call listChildren() on a key that doesn't exist, you just get a generic error.  I wanted to make it behave more like get(), where if the key doesn't exist you just get null back. 
